### PR TITLE
Improve seller scraping and message injection

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -18,39 +18,25 @@
 
     let seller = '';
     try {
-        const potentialSellers = document.querySelectorAll('a[role="link"][href*="/marketplace/"]');
-        
-        for (const link of potentialSellers) {
-            const nameSpan = link.querySelector('span.x193iq5w, span');
+        // Prefer explicit profile links first
+        let links = document.querySelectorAll('a[href*="/marketplace/profile/"]');
+        if (!links.length) {
+            // Fallback to more generic marketplace links
+            links = document.querySelectorAll('a[role="link"][href*="/marketplace/"]');
+        }
 
-            if (nameSpan) {
-                const potentialName = nameSpan.textContent.trim();
-                if (potentialName.length > 2 && !potentialName.includes(" ") && !potentialName.toLowerCase().includes('details')) {
-                    if (link.textContent.trim() === potentialName) {
-                        seller = potentialName;
-                        break;
-                    }
-                } else if (potentialName.includes(" ")) {
-                    if (link.textContent.trim() === potentialName) {
-                        seller = potentialName;
-                        break;
-                    }
-                }
+        for (const link of links) {
+            const text = (link.querySelector('span.x193iq5w, span') || link).textContent.trim();
+            if (!text || text.toLowerCase().includes('browse all') || text.toLowerCase().includes('see more')) {
+                continue; // skip navigation links
             }
+
+            seller = text;
+            break;
         }
 
         if (!seller) {
-            const containerSpans = document.querySelectorAll('span[dir="auto"]');
-            for (const containerSpan of containerSpans) {
-                const actualSellerLink = containerSpan.querySelector('a[role="link"][href*="/marketplace/profile/"]');   
-                if (actualSellerLink) {
-                    const nameSpan = actualSellerLink.querySelector('span.x193iq5w, span');
-                    if (nameSpan) {
-                        seller = nameSpan.textContent.trim();
-                        break;   
-                    }
-                }
-            }
+            console.warn('❌ Seller name not found.');
         }
 
     } catch (e) {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -82,9 +82,12 @@ async function autoTypeMessage(tabId, msg) {
         await chrome.scripting.executeScript({
             target: { tabId: tabId },
             func: (messageToType) => {
-                // Use the robust selector: textarea with specific aria-label and placeholder
-                const textarea = document.querySelector('textarea[aria-label="Send seller a message"][placeholder="Send a private message…"]');
-                
+                // Locate the message box. Facebook occasionally tweaks the placeholder
+                // text, so check by aria-label first and fall back to a more generic query.
+                const textarea =
+                    document.querySelector('textarea[aria-label="Send seller a message"]') ||
+                    document.querySelector('textarea[placeholder^="Send a"]');
+
                 if (!textarea) {
                     console.warn("❌ Textarea not found on Marketplace page.");
                     return; // Don't proceed if textarea is not found


### PR DESCRIPTION
## Summary
- get a more robust seller name from Marketplace pages
- relax selector for autofilling the chat textarea

## Testing
- `python3 -m py_compile src/main/main.py src/utils/scraper.py src/test/test.py src/test/ttttttetst.py`

------
https://chatgpt.com/codex/tasks/task_e_684210d45de88330b06474db8ab7fbab